### PR TITLE
Add new configure option --with-rst2man and --with-rst2html

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,11 +23,15 @@ AC_PROG_LIBTOOL
 AC_PROG_MAKE_SET
 
 # Check for rst utilities
-AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], "no")
-if test "x$RST2MAN" = "xno"; then
-	AC_MSG_WARN([rst2man not found - not building man pages])
-fi
-AM_CONDITIONAL(HAVE_RST2MAN, [test "x$RST2MAN" != "xno"])
+AC_ARG_WITH([rst2man],
+               AS_HELP_STRING([--with-rst2man=PATH],
+                              [Location of rst2man (auto)]),
+               [RST2MAN="$withval"],
+               [AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], "no")
+	        if test "x$RST2MAN" = "xno"; then
+		   AC_MSG_WARN([rst2man not found - not building man pages])
+		fi])
+AM_CONDITIONAL(HAVE_RST2MAN,[test "x$RST2MAN" != "xno"])
 
 # Checks for header files.
 AC_HEADER_STDC


### PR DESCRIPTION
Hi, I'm trying to compile this vmod on mac with homwbrew, but somehow I've got some problem with rst2man and cannot install this vmod properly. So I need to add 2 new options to specify the path to rst2man and rst2html

Please accept my request.